### PR TITLE
Add mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ default:
 	honcho start
 
 dockerfiles:
+	mkdir -p docker/
 	wget -O docker/$(RHEL6_DOCKRFILE) https://raw.githubusercontent.com/dincamihai/dockerfiles/master/Dockerfile.rhel6.products
 	wget -O docker/$(RHEL7_DOCKRFILE) https://raw.githubusercontent.com/dincamihai/dockerfiles/master/Dockerfile.rhel7.products
 


### PR DESCRIPTION
Added mkdir, otherwise an error is raised:

(sandbox) mbologna@echo:~/rhel-onboarding (master _%=) % make dockerfiles
wget -O docker/"Dockerfile.rhel6.products" https://raw.githubusercontent.com/dincamihai/dockerfiles/master/Dockerfile.rhel6.products
docker/Dockerfile.rhel6.products: No such file or directory
Makefile:9: recipe for target 'dockerfiles' failed
make: *_\* [dockerfiles] Error 1
